### PR TITLE
Feature/add utag data and license info

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+package.json
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "arrowParens": "avoid",
+    "semi": false
+}
+  

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-    "arrowParens": "avoid",
-    "semi": false
+  "arrowParens": "avoid",
+  "semi": false
 }
-  

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,45 @@
+The MIT License (MIT)
+
+Copyright © 2021 Alloy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This software uses [gatsby-plugin-tealium-utag](https://github.com/LatitudeFinancialOSS/gatsby-plugin-tealium-utag), which is unde the MIT license.
+
+The MIT License (MIT)
+
+Copyright © 2021 Latitude Financial Services
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ module.exports = {
       options: {
         account: "YOUR ACCOUNT ID",
         profile: "YOUR PROFILE ID",
-        utagData: { key : "value" } // Optional object for initial UDO (utag_data) definition.
+        utagData: { key : "value" } // Optional object for initial UDO (utag_data) definition. If not provided, utag_data object is not created.
         env: "dev", // Either dev, qa, or prod
         injectUtagSync: true, // Toggles async loading for utag script
         disableInitialTracking: false, // Toggles tracking of initial pageload

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ module.exports = {
       options: {
         account: "YOUR ACCOUNT ID",
         profile: "YOUR PROFILE ID",
+        utagData: { key : "value" } // Optional object for initial UDO (utag_data) definition.
         env: "dev", // Either dev, qa, or prod
         injectUtagSync: true, // Toggles async loading for utag script
         disableInitialTracking: false, // Toggles tracking of initial pageload
@@ -24,27 +25,24 @@ module.exports = {
 ## Example
 
 ```tsx
-import {
-  useTealiumViewEvent,
-  useTealiumLinkEvent,
-} from "gatsby-plugin-tealium";
+import { useTealiumViewEvent, useTealiumLinkEvent } from "gatsby-plugin-tealium"
 
 const Page: GatsbyPage = () => {
   useTealiumViewEvent({
     key: "value",
-  });
+  })
 
   const clickEvent = () => {
     useTealiumLinkEvent({
       key: "value",
-    });
-  };
+    })
+  }
 
   return (
     <>
       <h1>Hello, world.</h1>
       <button onClick={clickEvent}>Click here!</button>
     </>
-  );
-};
+  )
+}
 ```

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,13 +1,22 @@
-// TODO: Add descriptions
+// TODO: Add remaining descriptions
 export const pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
-    account: Joi.string().required().description(``),
-    profile: Joi.string().required().description(``),
-    utagData:Joi.string().required().description(``),
-    env: Joi.string().valid("dev", "qa", "prod").description(``).default(`default message`),
+    account: Joi.string()
+      .required()
+      .description(`Tealium account name, e.g. "companyXYZ"`),
+    profile: Joi.string()
+      .required()
+      .description(`Tealium profile name, e.g. "main"`),
+    utagData: Joi.object().description(
+      `Initial value for the Universal Data Object (UDO). If not provided, a UDO will not be set automatically. An empty object is accepted as a value.`
+    ),
+    env: Joi.string()
+      .valid("dev", "qa", "prod")
+      .description(`Tealium environment name, e.g. "prod"`)
+      .default(`default message`),
     injectUtagSync: Joi.boolean().description(``).default(true),
-    disableInitialTracking: Joi.boolean().description(``).default(`default message`)
-  }).external(async (pluginOptions) => {
+    disableInitialTracking: Joi.boolean().description(``).default(false),
+  }).external(async pluginOptions => {
     const url = `https://tags.tiqcdn.com/utag/${pluginOptions.account}/${pluginOptions.profile}/${pluginOptions.env}/utag.sync.js`
     try {
       const res = await fetch(url)
@@ -16,7 +25,7 @@ export const pluginOptionsSchema = ({ Joi }) => {
     } catch (err) {
       throw new Error(
         `Cannot access Tealium utag at "${url}". Please check your gatsby-plugin-tealium settings and try again!`
-      );
+      )
     }
-  });
-};
+  })
+}

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -3,6 +3,7 @@ export const pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
     account: Joi.string().required().description(``),
     profile: Joi.string().required().description(``),
+    utagData:Joi.string().required().description(``),
     env: Joi.string().valid("dev", "qa", "prod").description(``).default(`default message`),
     injectUtagSync: Joi.boolean().description(``).default(true),
     disableInitialTracking: Joi.boolean().description(``).default(`default message`)

--- a/gatsby-ssr.ts
+++ b/gatsby-ssr.ts
@@ -46,14 +46,15 @@ export const onRenderBody = (
           `,
         },
       }),
-      // TODO: Check if the use of dangerouslySetInnerHTML here is a security risk. Set type of utagData as an object.
-      // If initial value for utag_data is not provided, do not set the utag_data variable
+      // TODO: Check if the use of dangerouslySetInnerHTML here is a security risk. Make better use of TypeScript here.
+      // "If initial value for utag_data is not provided or it is not an object, do not set the utag_data variable."
       React.createElement("script", {
         key: "utagDataObject",
         dangerouslySetInnerHTML: {
-          __html: utagData
-            ? `var utag_data = ${JSON.stringify(utagData)}`
-            : null,
+          __html:
+            typeof utagData === "object"
+              ? `var utag_data = ${JSON.stringify(utagData)}`
+              : null,
         },
       }),
     ])

--- a/gatsby-ssr.ts
+++ b/gatsby-ssr.ts
@@ -45,7 +45,7 @@ export const onRenderBody = (
           `,
         },
       }),
-      // TODO: Check if the use of dangerouslySetInnerHTML here is a security risk.
+      // TODO: Check if the use of dangerouslySetInnerHTML here is a security risk. Set type of utagData as an object.
       // If initial value for utag_data is not provided, do not set the utag_data variable
       React.createElement("script", {
         key: "utagDataObject",

--- a/gatsby-ssr.ts
+++ b/gatsby-ssr.ts
@@ -1,5 +1,6 @@
 import React from "react"
 import { oneLineTrim } from "common-tags"
+import { OnRenderBodyOptions } from "./global"
 
 export const onRenderBody = (
   { setHeadComponents, setPreBodyComponents },
@@ -10,7 +11,7 @@ export const onRenderBody = (
     utagData,
     injectUtagSync = false,
     disableInitialTracking = false,
-  }
+  }: OnRenderBodyOptions
 ) => {
   if (["dev", "qa", "prod"].includes(env)) {
     if (injectUtagSync) {

--- a/gatsby-ssr.ts
+++ b/gatsby-ssr.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from "react"
 import { oneLineTrim } from "common-tags"
 
 export const onRenderBody = (
@@ -7,6 +7,7 @@ export const onRenderBody = (
     account,
     profile,
     env = "dev",
+    utagData,
     injectUtagSync = false,
     disableInitialTracking = false,
   }
@@ -18,7 +19,7 @@ export const onRenderBody = (
           key: "plugin-tealium-utag-sync",
           src: `https://tags.tiqcdn.com/utag/${account}/${profile}/${env}/utag.sync.js`,
         }),
-      ]);
+      ])
     }
 
     setPreBodyComponents([
@@ -26,12 +27,13 @@ export const onRenderBody = (
         key: "plugin-tealium-utag",
         dangerouslySetInnerHTML: {
           __html: oneLineTrim`
-            ${disableInitialTracking
-              ? `
+            ${
+              disableInitialTracking
+                ? `
               window.utag_cfg_ovrd = window.utag_cfg_ovrd || {};
               window.utag_cfg_ovrd.noview = true;
             `
-              : ""
+                : ""
             }
             (function(a,b,c,d){
               a='//tags.tiqcdn.com/utag/${account}/${profile}/${env}/utag.js';
@@ -43,10 +45,37 @@ export const onRenderBody = (
           `,
         },
       }),
-    ]);
+      // TODO: Check if the use of dangerouslySetInnerHTML here is a security risk.
+      // If initial value for utag_data is not provided, do not set the utag_data variable
+      React.createElement("script", {
+        key: "utagDataObject",
+        dangerouslySetInnerHTML: {
+          __html: utagData
+            ? `var utag_data = ${JSON.stringify(utagData)}`
+            : null,
+        },
+      }),
+    ])
   } else {
     throw new Error(
       `Unknown env: [${env}]. env must be "dev", "qa", or "prod".`
-    );
+    )
   }
-};
+}
+
+// Reorder the pre-body components to ensure that the utagDataObject is set prior to utag.js, which is added to the <body> via gatsby-plugin-tealium-utag
+export const onPreRenderHTML = ({
+  getPreBodyComponents,
+  replacePreBodyComponents,
+}) => {
+  const preBodyComponents = getPreBodyComponents()
+  preBodyComponents.sort((x, y) => {
+    if (x.key === "utagDataObject") {
+      return -1
+    } else if (y.key === "utagDataObject") {
+      return 1
+    }
+    return 0
+  })
+  replacePreBodyComponents(preBodyComponents)
+}

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,9 +1,18 @@
 declare global {
-    interface Window {
-        utag: any
-    }
+  interface Window {
+    utag: any
+  }
 }
 
 export type TealiumEvent = {
-    type: string
+  type: string
+}
+
+export type OnRenderBodyOptions = {
+  account: string
+  profile: string
+  env?: string
+  utagData?: object
+  injectUtagSync: boolean
+  disableInitialTracking: boolean
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Alloy <dev@alloy.digital> (http://alloy.digital)",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "react": "^16.8.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-tealium",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple tools for including and interacting with Tealium in Gatsby projects.",
   "author": "Alloy <dev@alloy.digital> (http://alloy.digital)",
   "main": "index.js",


### PR DESCRIPTION
Adds the option to provide initial data for utag_data (Universal Data Object for Tealium).

Also includes MIT license and attribution to gatsby-plugin-tealium-utag