### PR TITLE
Fix/remove default page view call

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,7 +1,0 @@
-import useTealiumViewEvent from "./hooks/useTealiumViewEvent"
-
-// export const onRouteUpdate = ({ location, prevLocation }, pluginOptions) => {
-//   useTealiumViewEvent({
-//     tealium_event: "homepage",
-//   })
-// }

--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,8 +1,7 @@
 import useTealiumViewEvent from "./hooks/useTealiumViewEvent"
 
-export const onRouteUpdate = ({ location, prevLocation }, pluginOptions) => {
-  useTealiumViewEvent({
-    pathName: location.pathname,
-    tealium_event: "page_view",
-  })
-}
+// export const onRouteUpdate = ({ location, prevLocation }, pluginOptions) => {
+//   useTealiumViewEvent({
+//     tealium_event: "homepage",
+//   })
+// }

--- a/global.d.ts
+++ b/global.d.ts
@@ -4,10 +4,6 @@ declare global {
   }
 }
 
-export type TealiumEvent = {
-  type: string
-}
-
 export type OnRenderBodyOptions = {
   account: string
   profile: string

--- a/hooks/useTealiumLinkEvent.ts
+++ b/hooks/useTealiumLinkEvent.ts
@@ -1,10 +1,14 @@
-import { TealiumEvent } from "../global.d"
-
-const useTealiumLinkEvent = (data: TealiumEvent): void => {
-  if (!window || !window.utag) {
-    console.error("utag.js has not loaded yet.")
-    return
+const useTealiumLinkEvent = (data = {}): void => {
+  const isBrowser = typeof window !== "undefined"
+  if (isBrowser) {
+    if (!window || !window.utag) {
+      console.error("utag.js has not loaded yet.")
+      return
+    } else {
+      window.utag.link(data)
+    }
+  } else {
+    console.error("window object is not currently available")
   }
-  window.utag.link(data)
 }
 export default useTealiumLinkEvent

--- a/hooks/useTealiumViewEvent.ts
+++ b/hooks/useTealiumViewEvent.ts
@@ -1,10 +1,21 @@
-import { TealiumEvent } from "../global.d"
+import { useEffect } from "react"
 
-const useTealiumViewEvent = (data: TealiumEvent): void => {
-  if (!window || !window.utag || !data) {
-    console.error("utag.js has not loaded yet.")
-    return
-  }
-  window.utag.view(data)
+// Todo: rethink !data  - is this correct?
+
+const useTealiumViewEvent = (data = {}): void => {
+  // Because of SSR use, in order to reference the window object, we must first verify that we are in the browser.
+  useEffect(() => {
+    const isBrowser = () => typeof window !== "undefined"
+    if (isBrowser) {
+      if (!window || !window.utag) {
+        console.error("utag.js has not loaded yet.")
+        return
+      } else {
+        window.utag.view(data)
+      }
+    } else {
+      console.error("window object is not currently available")
+    }
+  }, [])
 }
 export default useTealiumViewEvent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-tealium",
-  "version": "1.0.3",
+  "version": "1.2.0",
   "description": "Simple tools for including and interacting with Tealium in Gatsby projects.",
   "author": "Alloy <dev@alloy.digital> (http://alloy.digital)",
   "main": "index.js",


### PR DESCRIPTION
This PR removes the automatic page view function call in gatsby-browser.js.  Instead, page view calls should be implemented in the project itself, as use-cases and the required data for each page view can vary.

The PR also updates checks for the window object because of the use of gatsby-ssr. 